### PR TITLE
APPDESCRIP-25: Update existing application repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # app-platform-complete
 
-Application descriptor repository for app-platform-complete.  Comprised of most modules not included in app-platform-minimal.
+Application descriptor repository for app-platform-complete. Comprised of most modules not included in
+app-platform-minimal.
 
 ## Modules
 
@@ -8,7 +9,6 @@ Application descriptor repository for app-platform-complete.  Comprised of most 
 |:----------------------------|
 | `mod-organizations`         |
 | `mod-graphql`               |
-| `mod-consortia-keycloak`    |
 | `mod-organizations-storage` |
 | `mod-orders`                |
 | `mod-orders-storage`        |
@@ -58,6 +58,8 @@ Application descriptor repository for app-platform-complete.  Comprised of most 
 | `mod-ebsconet`              |
 | `mod-fqm-manager`           |
 | `mod-lists`                 |
+| `mod-batch-print`           |
+| `mod-serials-management`    |
 
 ## UI Modules
 
@@ -82,7 +84,7 @@ Application descriptor repository for app-platform-complete.  Comprised of most 
 | `folio_plugin-create-inventory-records` |
 | `folio_plugin-find-instance`            |
 | `folio_plugin-find-package-title`       |
-| `folio_checkin`                         | 
+| `folio_checkin`                         |
 | `folio_checkout`                        |
 | `folio_circulation`                     |
 | `folio_plugin-find-user`                |
@@ -115,5 +117,6 @@ Application descriptor repository for app-platform-complete.  Comprised of most 
 | `folio_service-interaction`             |
 | `folio_users`                           |
 | `folio_lists`                           |
-| `folio_consortia-settings`              |
+| `folio_serials-management`              |
+| `folio_stripes-marc-components`         |
 

--- a/app-platform-complete.template.json
+++ b/app-platform-complete.template.json
@@ -19,10 +19,6 @@
       "version": "latest"
     },
     {
-      "name": "mod-consortia-keycloak",
-      "version": "latest"
-    },
-    {
       "name": "mod-organizations-storage",
       "version": "latest"
     },
@@ -219,27 +215,15 @@
       "version": "latest"
     },
     {
-      "name": "mod-serials-management",
-      "version": "latest"
-    },
-    {
-      "name": "mod-circulation-item",
-      "version": "latest"
-    },
-    {
-      "name": "mod-dcb",
-      "version": "latest"
-    },
-    {
       "name": "mod-batch-print",
+      "version": "latest"
+    },
+    {
+      "name": "mod-serials-management",
       "version": "latest"
     }
   ],
   "uiModules": [
-    {
-      "name": "folio_serials-management",
-      "version": "latest"
-    },
     {
       "name": "folio_organizations",
       "version": "latest"
@@ -449,7 +433,7 @@
       "version": "latest"
     },
     {
-      "name": "folio_consortia-settings",
+      "name": "folio_serials-management",
       "version": "latest"
     },
     {


### PR DESCRIPTION
### Purpose
- Bring the HEAD/master of these repos up to date (set of modules, application dependencies, application version in pom.xml, etc.).
- See [application-descriptors/Quesnelia at Quesnelia.SP1 · folio-org/application-descriptors](https://github.com/folio-org/application-descriptors/tree/Quesnelia.SP1/Quesnelia) 
- The module versions in the master branch should be “latest” to allow for snapshot versions of the application descriptors to be generated.

[APPDESCRIP-25](https://folio-org.atlassian.net/browse/APPDESCRIP-25)