### PR TITLE
Remove reading room modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ app-platform-minimal.
 | `mod-tlr`                   |
 | `mod-record-specifications` |
 | `mod-requests-mediated`     |
-| `mod-reading-room`          |
 | `mod-circulation-bff`       |
 
 ## UI Modules
@@ -126,4 +125,3 @@ app-platform-minimal.
 | `folio_stripes-marc-components`         |
 | `folio_requests-mediated`               |
 | `folio_stripes-inventory-components`    |
-| `folio_reading-room`                    |

--- a/app-platform-complete.template.json
+++ b/app-platform-complete.template.json
@@ -235,10 +235,6 @@
       "version": "latest"
     },
     {
-      "name": "mod-reading-room",
-      "version": "latest"
-    },
-    {
       "name": "mod-circulation-bff",
       "version": "latest"
     }
@@ -466,10 +462,6 @@
     },
     {
       "name": "folio_stripes-inventory-components",
-      "version": "latest"
-    },
-    {
-      "name": "folio_reading-room",
       "version": "latest"
     }
   ]


### PR DESCRIPTION
Since we have separated application for reading room, removing it from platform-complete
From interface perspective, this should not be an issue.