### PR TITLE
Remove request-mediated && mod-tlr

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ app-platform-minimal.
 | `mod-lists`                 |
 | `mod-batch-print`           |
 | `mod-serials-management`    |
-| `mod-tlr`                   |
 | `mod-record-specifications` |
-| `mod-requests-mediated`     |
 | `mod-reading-room`          |
 | `mod-circulation-bff`       |
 
@@ -124,6 +122,5 @@ app-platform-minimal.
 | `folio_lists`                           |
 | `folio_serials-management`              |
 | `folio_stripes-marc-components`         |
-| `folio_requests-mediated`               |
 | `folio_stripes-inventory-components`    |
 | `folio_reading-room`                    |

--- a/app-platform-complete.template.json
+++ b/app-platform-complete.template.json
@@ -223,15 +223,7 @@
       "version": "latest"
     },
     {
-      "name": "mod-tlr",
-      "version": "latest"
-    },
-    {
       "name": "mod-record-specifications",
-      "version": "latest"
-    },
-    {
-      "name": "mod-requests-mediated",
       "version": "latest"
     },
     {
@@ -458,10 +450,6 @@
     },
     {
       "name": "folio_stripes-marc-components",
-      "version": "latest"
-    },
-    {
-      "name": "folio_requests-mediated",
       "version": "latest"
     },
     {


### PR DESCRIPTION
Due to the creation of separated applications, removing from platform-complete. Verified that there is no interface dependency issues.
https://github.com/folio-org/app-requests-mediated
https://github.com/folio-org/app-requests-ecs