### PR TITLE
MODSER-129. Move serials management modules to separate application [to snapshot]

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ app-platform-minimal.
 | `mod-inventory-update`      |
 | `mod-user-import`           |
 | `mod-batch-print`           |
-| `mod-serials-management`    |
 | `mod-record-specifications` |
 
 ## UI Modules
@@ -76,6 +75,5 @@ app-platform-minimal.
 | `folio_myprofile`                       |
 | `folio_plugin-find-authority`           |
 | `folio_users`                           |
-| `folio_serials-management`              |
 | `folio_stripes-marc-components`         |
 | `folio_stripes-inventory-components`    |

--- a/app-platform-complete.template.json
+++ b/app-platform-complete.template.json
@@ -143,10 +143,6 @@
       "version": "latest"
     },
     {
-      "name": "mod-serials-management",
-      "version": "latest"
-    },
-    {
       "name": "mod-record-specifications",
       "version": "latest"
     }
@@ -258,10 +254,6 @@
     },
     {
       "name": "folio_users",
-      "version": "latest"
-    },
-    {
-      "name": "folio_serials-management",
       "version": "latest"
     },
     {


### PR DESCRIPTION
New application created with mod-serials-management and ui-serials-management
https://github.com/folio-org/app-serials-management,
now need to delete these 2 modules from app-platform-complete